### PR TITLE
Fix Coolify compose network routing

### DIFF
--- a/docker/compose/docker-compose-blank-network.yml
+++ b/docker/compose/docker-compose-blank-network.yml
@@ -3,47 +3,18 @@ services:
     build:
       context: .
       args:
-        SERVER_NAME: ${SERVER_NAME}
-        APT_PACKAGES: ${APT_PACKAGES}
+        SERVER_NAME: board
     container_name: "${PROJECT_NAME}-server"
     restart: always
     stdin_open: true
     tty: true
-    ports:
-      - "127.0.0.1:${HTTP_PORT}:80"
-      - "127.0.0.1:${HTTPS_PORT}:443"
-    links:
-      - database:database
     volumes:
-      - ./classes:/var/www/html/classes:rw
-      - ./public:/var/www/html/public:rw
-      - ./views:/var/www/html/views:rw
-      - ./util:/var/www/html/util:rw
-      - ./loader.php:/var/www/html/loader.php:rw
       - .config.json:/var/www/html/.config.json
-      - ./docker/apache/${SERVER_NAME}.conf:/etc/apache2/sites-available/${SERVER_NAME}.conf
+      - ./docker/apache/boards.conf:/etc/apache2/sites-available/boards.conf
       - ./docker/logs/error.log:/var/log/apache2/error.log
       - ./docker/logs/access.log:/var/log/apache2/other_vhosts_access.log
       - ./docker/logs/debug.txt:/var/www/html/debug.txt
-      - ./docker/php/board.ini:/etc/php/7.4/apache2/conf.d/board.ini
-      - ./docker/ssl/${SERVER_NAME}.key:/etc/apache2/ssl/${SERVER_NAME}.key
-      - ./docker/ssl/${SERVER_NAME}.crt:/etc/apache2/ssl/${SERVER_NAME}.crt
-      - ./docker/volumes/cache:/tmp/myCache # lol
-      - ./docker/volumes/demos:/var/www/html/demos
-      - ./docker/volumes/sessions:/var/www/html/sessions
-  database:
-    image: mariadb:11.4.2
-    container_name: "${PROJECT_NAME}-db"
-    restart: unless-stopped
-    ports:
-      - "127.0.0.1:${DATABASE_PORT}:3306"
-    environment:
-      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
-      MARIADB_USER: ${MARIADB_USER}
-      MARIADB_PASSWORD: ${MARIADB_PASSWORD}
-      MARIADB_DATABASE: ${MARIADB_DATABASE}
-      MYSQL_TCP_PORT: 3306
-    volumes:
-      - ./docker/initdb:/docker-entrypoint-initdb.d
-      - ./docker/volumes/mysql:/var/lib/mysql
-      - ./docker/volumes/backups:/backups
+      - ./docker/php/board.ini:/usr/local/etc/php/conf.d/php.ini
+      - ./docker/volumes/cache:/var/www/html/cache:rw
+      - ./docker/volumes/demos:/var/www/html/demos:rw
+      - ./docker/volumes/sessions:/var/www/html/sessions:rw

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     restart: always
     stdin_open: true
     tty: true
+    networks:
+      - default
+      - board-net
     volumes:
       - .config.json:/var/www/html/.config.json
       - ./docker/apache/boards.conf:/etc/apache2/sites-available/boards.conf
@@ -18,3 +21,6 @@ services:
       - ./docker/volumes/cache:/var/www/html/cache:rw
       - ./docker/volumes/demos:/var/www/html/demos:rw
       - ./docker/volumes/sessions:/var/www/html/sessions:rw
+networks:
+    board-net:
+      name: board-net

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -8,9 +8,6 @@ services:
     restart: always
     stdin_open: true
     tty: true
-    networks:
-      - default
-      - board-net
     volumes:
       - .config.json:/var/www/html/.config.json
       - ./docker/apache/boards.conf:/etc/apache2/sites-available/boards.conf
@@ -21,6 +18,3 @@ services:
       - ./docker/volumes/cache:/var/www/html/cache:rw
       - ./docker/volumes/demos:/var/www/html/demos:rw
       - ./docker/volumes/sessions:/var/www/html/sessions:rw
-networks:
-    board-net:
-      name: board-net


### PR DESCRIPTION
## Summary
- remove the custom `board-net` network from the Coolify compose service
- leave the server on the default Coolify-managed Docker network so Traefik does not choose an unreachable service IP

## Verification
- ran `docker compose -f docker/compose/docker-compose.yml config`
- confirmed the rendered `server` service now only has `networks.default`